### PR TITLE
Updated gradle uri in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Minimum code for Gradle integration, place code in your `build.gradle`
 
 ```gradle
 dependencies {
-  compile 'com.commit451:PhotoView:1.2.4'
+  compile 'com.github.chrisbanes.photoview:library:+'
 }
 ```
 


### PR DESCRIPTION
I changed the gradle uri in the documentation as using the com.commit451:photoview:1.2.4 results in a failed build.
